### PR TITLE
Dockerizing Agency API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+.dockerignore
+node_modules
+npm-debug.log
+README.md
+.git
+6

--- a/.env-example
+++ b/.env-example
@@ -6,8 +6,13 @@
 
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://username:password@databaseUrl:Port/databaseName?schema=schema"
+DATABASE_URL="postgresql://postgres:postgres@db:5432/postgres?schema=schema"
 PORT=NUMBER
 
 #jwt
 SECRETSAUCE=ITSASECRETSSSSSH!
+
+#docker
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Base stage
+FROM node:20.11-alpine
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY prisma ./prisma/
+RUN npx prisma generate
+
+COPY . .
+
+EXPOSE 3000
+ENTRYPOINT ["npm", "run", "start:migrate:prod"]
+

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,16 @@
+# Base stage
+FROM node:20.11-alpine
+WORKDIR /app
+
+COPY package*.json ./
+
+ENV NODE_ENV=development
+RUN npm install
+
+COPY prisma ./prisma/
+RUN npx prisma generate
+
+COPY . .
+
+EXPOSE 3000
+ENTRYPOINT ["npm", "run", "watch"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-
     ports:
       - 3000:3000
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+
+services:
+  api:
+    container_name: noroff_agency_api
+    restart: on-failure
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    ports:
+      - 3000:3000
+    env_file:
+      - .env
+    networks:
+      - noroff
+    depends_on:
+      - db
+
+  db:
+    image: postgres:15-alpine
+    restart: on-failure
+    container_name: noroff_agency_api_db
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres_storage:/var/lib/postgresql/data
+    networks:
+      - noroff
+
+volumes:
+  postgres_storage:
+
+networks:
+  noroff:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     restart: on-failure
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     ports:
       - 3000:3000
     env_file:
@@ -15,6 +15,9 @@ services:
       - noroff
     depends_on:
       - db
+    volumes:
+      - .:/app
+      - /app/node_modules
 
   db:
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   api:
     container_name: noroff_agency_api
     restart: on-failure
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile.dev

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint-fix": "eslint src/**/*.js --cache --fix",
     "prepare": "husky install",
     "test": "npm run test-unit",
-    "test-unit": "jest --coverage --verbose --forceExit"
+    "test-unit": "jest --coverage --verbose --forceExit",
+    "start:migrate:prod": "npx prisma migrate deploy && npm run start"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR introduces Docker and docker-compose to the Agency API, streamlining the development and deployment processes.

Here's what you need to do to get going:
- Add `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` to your .env file. Make sure `DATABASE_URL` matches the Postgres service name in docker-compose.
  - The updated .env.example file uses `db:5432` for the DATABASE_URL, which is correct with the current setup.
- If you don't have it yet, install Docker Compose. [Guide](https://docs.docker.com/compose/install/)
  - Recommended to install Docker Desktop. This will include Docker Compose by default.
  - Mac users, try [OrbStack](https://orbstack.dev/) if Docker Desktop feels heavy or uses too much battery.
- Open your terminal, navigate to the project folder, and run `docker-compose up -d`. This gets both the API and Postgres running in Docker.

To stop the docker containers when you're done, just run `docker-compose down`

Feel free to reach out, _or open a issue/PR and tag me_, if you encounter any issues or have suggestions for improvements to the setup :-)