### PR TITLE
Easy to use testing scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "lint-fix": "eslint src/**/*.js --cache --fix",
     "prepare": "husky install",
     "test": "npm run test-unit",
+    "test-user": "jest --coverage --verbose --forceExit src/modules/user/routes.test.js",
+    "test-company": "jest --coverage --verbose --forceExit src/modules/company/routes.test.js",
+    "test-application": "jest --coverage --verbose --forceExit src/modules/application/routes.test.js",
+    "test-listing": "jest --coverage --verbose --forceExit src/modules/listing/routes.test.js",
+    "test-offer": "jest --coverage --verbose --forceExit src/modules/offer/routes.test.js",
     "test-unit": "jest --coverage --verbose --forceExit"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run test-unit",
     "test-user": "jest --coverage --verbose --forceExit src/modules/user/routes.test.js",
     "test-company": "jest --coverage --verbose --forceExit src/modules/company/routes.test.js",
-    "test-application": "jest --coverage --verbose --forceExit src/modules/application/routes.test.js",
+    "test-application": "jest --coverage --verbose --forceExit src/modules/application/test/routes.test.js",
     "test-listing": "jest --coverage --verbose --forceExit src/modules/listing/routes.test.js",
     "test-offer": "jest --coverage --verbose --forceExit src/modules/offer/routes.test.js",
     "test-unit": "jest --coverage --verbose --forceExit"

--- a/src/modules/user/routes.test.js
+++ b/src/modules/user/routes.test.js
@@ -74,7 +74,9 @@ describe("POST /users", () => {
       lastName: testUser.lastName,
       password: testUser.password,
     });
-    expect(response.body.message).toEqual("Missing required field, firstName.");
+    expect(response.body.message).toEqual(
+      "Invalid value in firstName field(s)"
+    );
     expect(response.statusCode).toBe(400);
   });
 
@@ -84,7 +86,7 @@ describe("POST /users", () => {
       firstName: testUser.firstName,
       password: testUser.password,
     });
-    expect(response.body.message).toEqual("Missing required field, lastName.");
+    expect(response.body.message).toEqual("Invalid value in lastName field(s)");
     expect(response.statusCode).toBe(400);
   });
 


### PR DESCRIPTION
To make it easier when wanting to test a particular module and not wanting to have to type out paths to test files I have added scripts to test each route.
Now you can run all tests with 
```
npm run test
```
or select a test for a particular route like so

```
npm  run  test-user
npm  run  test-company
npm  run  test-application
npm  run  test-listing
npm  run  test-offer
```

As it stands we have working tests for user, company, listing and application routes, these may need further tests based on bugs and issues raised.
